### PR TITLE
Feature/macro config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,167 +52,33 @@ calibration, ...).
    ```
    [include voron_klipper/main.cfg]
    ```
+5. Add `VORONklipper` configuration (See [Usage](#usage) below)
+
+## Updating
+
+If you did not change the macro files, you can safely
+
+1. SSH into your PI
+2. Switch to your `VORONklipper` installation directory
+3. Run
+   ```
+   git pull
+   ```
 
 ## Usage
 
-To make use of VORONklipper you need to configure some parameters first.
-In order to do so you have to add one gcode macro to your `printer.cfg`
+To make use of `VORONklipper` you need to configure some parameters first.
+In order to do so you have to add one small gcode macro to your `printer.cfg`. 
+Please read the [configuration document](https://github.com/rampage128/voron-klipper/blob/main/docs/configuration.md) 
+on how to do that and then continue with this page.
 
-```
-[gcode_macro VORON_CONFIG]
-variable_brush_active: false
-variable_brush_x: 100
-variable_brush_y: 350
-variable_brush_z: 3
-variable_brush_width: 50
-variable_brush_orientation: x
-variable_brush_strokes: 5
-gcode:
-```
-
-Unfortunately klipper does not allow to create custom config sections/values. 
-Adding this macro to your `printer.cfg` serves as a work-around to enable 
-configuration of `VORONklipper` without having to edit the individual macro 
-files directly.
-
-VORONklipper provides macros for you to call from octoprint/mainsail or what 
-ever UI you use. Usage of the individual macros can be found under the 
-[Commands](#commands) section below.
+`VORONklipper` provides macros for you to call from octoprint/mainsail or what 
+ever UI you use. Usage of the individual macros can be found in the 
+[commands document](https://github.com/rampage128/voron-klipper/blob/main/docs/commands.md).
 
 Additionally you can make use of the built in `print_start` and `print_end` 
-macros. In order to do so, just remove the ones you have in your `printer.cfg`.
-
-## Commands
-These are the commands that are meant to be directly used from outside 
-(octoprint, ...).
-
-### __clean nozzle__
-```
-CLEAN_NOZZLE X=<brush X position> Y=<brush Y position> Z=<brush top> L=<brush length> O=<Brush orientation x|y> [STROKES=<number of strokes>]
-```
-Will perform a cleaning routine with the nozzle on a brush. You can input the 
-position and orientation of the brush as well as the amount of cleaning strokes.
-
-The orientation of the brush can either be specified as `x` or `y`. It will be 
-the axis along which the cleaning strokes will be performed. Originally this 
-was planned to be an angle relative to the X-axis. Unfortunately klipper does 
-not support sine and cosine functions, so we have to stick to two fixed axes.
-
-By default the routine will perform 5 strokes (back and forth counts as 1).
-You can override the amount by providing the `STROKES` parameter with your 
-number of choice.
-
-> _Please note:_ This command will automatically perform a homing routine if 
-  the printer is currently not homed yet.
-
-### __heat__
-```
-HEAT EXTRUDER=<extruder temperature> [BED=<bed temperature>] [BLOCK=<true|false>]
-```
-Will heat up the Extruder (and bed if a bed temperature is specified). By default 
-this command will block the printer until the temperature is reached 
-(M109/M190). You can specify `BLOCK=false` to avoid that.
-
-### __load or create mesh__
-```
-LOAD_OR_CREATE_MESH [PROFILE=<profile name>]
-```
-This will load a bed mesh for the given profile name. If the bed mesh does not 
-exist, it will be created and activated automatically. If you do not specify 
-a profile name, the default profile will be used.
-
-> _Please note:_ This command will automatically perform a homing routine if 
-  the printer is currently not homed yet.
-
-### __park__
-```
-PARK [X=<X coordinate>] [HOP=<Distance to hop>]
-```
-Will park the toolhead at the back of the build volume. You can specify `X` as 
-absolute coordinate to move the toolhead on the X axis as well. If you do not 
-provide `X`, the toolhead will stay on it's current X-coordinate. If you 
-provide a value for `HOP`, the toolhead will move up by that amount _before_ 
-commencing parking.
-
-> _Please note:_ This command will automatically perform a homing routine if 
-  the printer is currently not homed yet.
-
-### __print end__
-```
-PRINT_END
-```
-Just retracts the filament, clears bed mesh and parks the toolhead at the back 
-of the printer. To make it work you have to remove your own `print_end` from 
-`printer.cfg`.
-
-### __print start__
-```
-PRINT_START EXTRUDER=<extruder temperature> [BED=<bed temperature>] [PROFILE=<profile name>]
-```
-Macro to automate print starts for different profiles. You can call this from 
-your slicer as start gcode. It will heat up the bed/extruder to the desired 
-temperatures, perform QGL and nozzle cleaning and load the bed mesh for the 
-given profile name. If there is no bed mesh yet, it will create one the first 
-time you use that profile name. To make it work you have to remove your own 
-`print_start` from `printer.cfg`.
-
-> _Please note:_ If you do not provide a profile, no bed mesh will be used.
-
-### __service__
-```
-SERVICE TYPE=<bed|extruder|nozzle|tool|z>
-```
-Moves the toolhead to a specific position in the build volume to allow easier 
-servicing of various areas of the printer. Available types are:
-- `bed`: Will move the toolhead to the X/Y center and move it all the way up. 
-  For maximum space above the print bed.
-- `extruder`: Will move the toolhead to the front and down and center it on X.
-  For easy access to the filament/extruder.
-- `nozzle`: Will move the toolhead to the front and up and center it on X.
-  For easy access to the nozzle.
-- `tool`: Will move the toolhead to the front and center it on X/Z.
-  For access to the toolhead as a whole.
-- `z`: Will center the toolhead on X/Y/Z. 
-  For optimal access to all the Z-belts.
-
-> _Please note:_ This command will automatically perform a homing routine if 
-  the printer is currently not homed yet.
-
-
-## Internal commands
-
-There are some internal commands that are not meant to be used independently, 
-but some of those might be helpful so here is an explanation:
-
-### __center x/y__
-```
-CENTER_XY
-```
-Will center the toolhead on X and Y.
-
-
-### __clear display__
-```
-UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
-```
-Can be called like this to clear the printers display after the specified 
-`DURATION`.
-
-### __feedback__
-```
-FEEDBACK MSG="<some string>"
-```
-Will print a message as info into the console and onto the display (m117).
-The messages in the console will be visible in octoklipper (and also show up 
-in the octoprint navigation bar).
-
-### __home__
-```
-HOME [OPTIONAL=<false|true>]
-```
-Will perform a G28 ... If parameter `OPTIONAL=true` is provided, it will only 
-perform the G28 if the printer is not homed on one of the X/Y/Z axes.
-
+macros as well as the `homing_override`. In order to do so please consult the 
+[overrides document](https://github.com/rampage128/voron-klipper/blob/main/docs/overrides.md).
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ calibration, ...).
 
 ## Usage
 
+To make use of VORONklipper you need to configure some parameters first.
+In order to do so you have to add one gcode macro to your `printer.cfg`
+
+```
+[gcode_macro VORON_CONFIG]
+variable_brush_active: false
+variable_brush_x: 100
+variable_brush_y: 350
+variable_brush_z: 3
+variable_brush_width: 50
+variable_brush_orientation: x
+variable_brush_strokes: 5
+gcode:
+```
+
+Unfortunately klipper does not allow to create custom config sections/values. 
+Adding this macro to your `printer.cfg` serves as a work-around to enable 
+configuration of `VORONklipper` without having to edit the individual macro 
+files directly.
+
 VORONklipper provides macros for you to call from octoprint/mainsail or what 
 ever UI you use. Usage of the individual macros can be found under the 
 [Commands](#commands) section below.

--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ If you did not change the macro files, you can safely
 
 To make use of `VORONklipper` you need to configure some parameters first.
 In order to do so you have to add one small gcode macro to your `printer.cfg`. 
-Please read the [configuration document](https://github.com/rampage128/voron-klipper/blob/main/docs/configuration.md) 
+Please read the [configuration document](docs/configuration.md) 
 on how to do that and then continue with this page.
 
 `VORONklipper` provides macros for you to call from octoprint/mainsail or what 
 ever UI you use. Usage of the individual macros can be found in the 
-[commands document](https://github.com/rampage128/voron-klipper/blob/main/docs/commands.md).
+[commands document](docs/commands.md).
 
 Additionally you can make use of the built in `print_start` and `print_end` 
 macros as well as the `homing_override`. In order to do so please consult the 
-[overrides document](https://github.com/rampage128/voron-klipper/blob/main/docs/overrides.md).
+[overrides document](docs/overrides.md).
 
 ## Contribute
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,120 @@
+# Commands - VORONklipper
+> A macro guide for VORONklipper
+
+This document contains information on the commands (gcode macros) that 
+`VORONklipper` provides for your use. For completeness there is also a list 
+of internal commands that are not meant to be called directly.
+
+## User Commands
+These commands are meant to be called directly for your convenience.
+
+### __clean nozzle__
+```
+CLEAN_NOZZLE
+```
+Will perform a cleaning routine with the nozzle on a brush. The position and 
+orientation of the brush as well as the amount of cleaning strokes are defined 
+in the [VORONklipper configuration](https://github.com/rampage128/voron-klipper/blob/main/docs/configuration.md).
+
+> _Please note:_ 
+> - This command will automatically perform a homing routine if 
+>   the printer is currently not homed yet.
+> - The brush has to be enabled in the [configuration](https://github.com/rampage128/voron-klipper/blob/main/docs/configuration.md).
+
+### __heat__
+```
+HEAT EXTRUDER=<extruder temperature> [BED=<bed temperature>] [BLOCK=<true|false>]
+```
+Will heat up the Extruder (and bed if a bed temperature is specified). By default 
+this command will block the printer until the temperature is reached 
+(M109/M190). You can specify `BLOCK=false` to avoid that.
+
+### __home__
+```
+HOME [OPTIONAL=<false|true>]
+```
+Will perform a G28 ... If parameter `OPTIONAL=true` is provided, it will only 
+perform the G28 if the printer is not homed on one of the X/Y/Z axes.
+
+### __load or create mesh__
+```
+LOAD_OR_CREATE_MESH [PROFILE=<profile name>]
+```
+This will load a bed mesh for the given profile name. If the bed mesh does not 
+exist, it will be created and activated automatically. If you do not specify 
+a profile name, the default profile will be used.
+
+> _Please note:_ 
+> - This command will automatically perform a homing routine if 
+>   the printer is currently not homed yet.
+> - This command is not functional since loading a non-existing profile 
+>   currently causes an error in klipper :-(
+
+### __park__
+```
+PARK [X=<X coordinate>] [HOP=<Distance to hop>]
+```
+Will park the toolhead at the back of the build volume. You can specify `X` as 
+absolute coordinate to move the toolhead on the X axis as well. If you do not 
+provide `X`, the toolhead will stay on it's current X-coordinate. If you 
+provide a value for `HOP`, the toolhead will move up by that amount _before_ 
+commencing parking.
+
+> _Please note:_ This command will automatically perform a homing routine if 
+  the printer is currently not homed yet.
+
+### __service__
+```
+SERVICE TYPE=<bed|extruder|nozzle|tool|z>
+```
+Moves the toolhead to a specific position in the build volume to allow easier 
+servicing of various areas of the printer. Available types are:
+- `bed`: Will move the toolhead to the X/Y center and move it all the way up. 
+  For maximum space above the print bed.
+- `extruder`: Will move the toolhead to the front and down and center it on X.
+  For easy access to the filament/extruder.
+- `nozzle`: Will move the toolhead to the front and up and center it on X.
+  For easy access to the nozzle.
+- `tool`: Will move the toolhead to the front and center it on X/Z.
+  For access to the toolhead as a whole.
+- `z`: Will center the toolhead on X/Y/Z. 
+  For optimal access to all the Z-belts.
+
+> _Please note:_ This command will automatically perform a homing routine if 
+  the printer is currently not homed yet.
+
+
+## Internal commands
+
+There are some internal commands that are not meant to be used independently, 
+but some of those might be helpful so here is an explanation:
+
+### __center x/y__
+```
+CENTER_XY
+```
+Will center the toolhead on X and Y.
+
+### __check config__
+```
+CHECK_VORON_CONFIG
+```
+This macro will raise an exception and link to the configuration document if 
+the configuration macro is not present. It is used in other macros that require 
+the configuration to be present.
+
+### __clear display__
+```
+UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
+```
+Can be called like this to clear the printers display after the specified 
+`DURATION`.
+
+### __feedback__
+```
+FEEDBACK MSG="<some string>"
+```
+Will print a message as info into the console and onto the display (m117).
+The messages in the console will be visible in octoklipper (and also show up 
+in the octoprint navigation bar).
+

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,12 +14,12 @@ CLEAN_NOZZLE
 ```
 Will perform a cleaning routine with the nozzle on a brush. The position and 
 orientation of the brush as well as the amount of cleaning strokes are defined 
-in the [VORONklipper configuration](https://github.com/rampage128/voron-klipper/blob/main/docs/configuration.md).
+in the [VORONklipper configuration](configuration.md#nozzle_cleaning).
 
 > _Please note:_ 
 > - This command will automatically perform a homing routine if 
 >   the printer is currently not homed yet.
-> - The brush has to be enabled in the [configuration](https://github.com/rampage128/voron-klipper/blob/main/docs/configuration.md).
+> - The brush has to be enabled in the [configuration](configuration.md#nozzle_cleaning).
 
 ### __heat__
 ```
@@ -99,9 +99,9 @@ Will center the toolhead on X and Y.
 ```
 CHECK_VORON_CONFIG
 ```
-This macro will raise an exception and link to the configuration document if 
-the configuration macro is not present. It is used in other macros that require 
-the configuration to be present.
+This macro will raise an error and link to the [configuration document](configuration.md) 
+if the configuration macro is not present. It is used in other macros to 
+prevent further execution of gcode if the required configuration is missing.
 
 ### __clear display__
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,69 @@
+# Configuration - VORONklipper
+> A config guide for VORONklipper
+
+Even though `VORONklipper` tries to determin positioning mathematically instead 
+of relying on modification of coordinates inside of gcode macros, some elements 
+need explicit configuration. This applies to features that require safety (like 
+the `homing_override`) and features that use additional user installed hardware 
+(like a nozzle brush).
+
+Unfortunately klipper does not allow to create custom config sections/values. 
+This is why `VORONklipper` uses a gcode macro as a workaround. This gcode macro 
+does not contain any gcode, but other macros can access its variables and use 
+them as a configuration.
+
+This approach has some advantages:
+- The `VORONklipper` files do not have to be changed to configure your printer.
+- You can update the macros without breaking your configuration.
+- No more complicated editing of gcode to configure your printer motion.
+- The configuration for all the macros is compact and easily readable in the 
+  `printer.cfg`, where it belongs.
+  
+## The VORON_CONFIG macro
+
+```
+[gcode_macro VORON_CONFIG]
+variable_z_endstop_x: 231
+variable_z_endstop_y: 347
+
+variable_brush_active: "true"
+variable_brush_x: 100
+variable_brush_y: 350
+variable_brush_z: 3
+variable_brush_width: 50
+variable_brush_orientation: "x"
+variable_brush_strokes: 5
+gcode:
+```
+
+The code above is the macro in question. You need to add this to your 
+`printer.cfg` to make use of `VORONklipper`. If you forget, 
+your printer will throw an error and link to this page.
+
+See below for an explanation of the different config values.
+
+## Config values
+
+### Endstop
+Instead of editing a `homing_override` section yourself, you can remove it from 
+your `printer.cfg` and instead use the one provided by `VORONklipper`:
+- `variable_z_endstop_x`: The X position of your Z-endstop pin.
+- `variable_z_endstop_y`: The Y position of your Z-endstop pin.
+
+### Nozzle cleaning brush
+`VORONklipper` includes a cleaning script for your nozzle. You can specify 
+the location, size and orientation of your nozzle as well as the number of 
+strokes to clean with.
+
+- `variable_brush_active`: Set to `"true"` to activate nozzle cleaning during 
+`print_start`.
+- `variable_brush_x`: The X position of the center of your brush.
+- `variable_brush_y`: The Y position of the center of your brush.
+- `variable_brush_z`: The height to wipe the nozzle at (pick a height that lets 
+   the nozzle wipe through the brush, but does not hit the carriage itself).
+- `variable_brush_width`: The width of the brush (this will determine the length 
+   of the wiping strokes performed).
+- `variable_brush_orientation`: `"x"` or `"y"`. The axis to perform the wiping 
+  strokes along.
+- `variable_brush_strokes`: The number of strokes to wipe with (back and forth 
+  counts as 1 stroke).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ your `printer.cfg` and instead use the one provided by `VORONklipper`:
 - `variable_z_endstop_x`: The X position of your Z-endstop pin.
 - `variable_z_endstop_y`: The Y position of your Z-endstop pin.
 
-### Nozzle cleaning brush
+### Nozzle cleaning
 `VORONklipper` includes a cleaning script for your nozzle. You can specify 
 the location, size and orientation of your nozzle as well as the number of 
 strokes to clean with.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -26,6 +26,8 @@ Z-offset during `print_start`. You can still force homing X/Y with a
 > To make it work you have to remove your own `homing_override` from 
 `printer.cfg`.
 
+> This override needs [configuration](configuration.md#endstop)!
+
 ## __print end__
 ```
 PRINT_END
@@ -61,6 +63,8 @@ next step. It is highly recommended, that you use the built in
 X/Y after every step. Especially after cleaning the nozzle this is important, 
 because new plastic could ooze out of the nozzle and throw off the offset.
 
-> _Please note:_ If you do not provide a profile, no bed mesh will be used.
+> _Please note:_ 
+> - If you do not provide a profile, no bed mesh will be used.
+> - Using `CLEAN=true` needs [configuration](configuration.md#nozzle_cleaning)!
 
 > To make it work you have to remove your own gcode macro `print_start` from `printer.cfg`.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -1,0 +1,66 @@
+# Overrides - VORONklipper
+> A guide to useful VORONklipper presets
+
+Overrides are tuned versions of standard klipper commands or actual overrides 
+of gcode commands that should probably be like this by default (at least for 
+VORON printers).
+
+Since klipper loads and applies the config from top to bottom. That means 
+that in general any macro or override you have in your `printer.cfg` will be 
+used instead of the ones provided by `VORONklipper`.
+To make use of the included ones, you have to remove the corresponding entries 
+from your `printer.cfg`.
+
+## __homing override__
+`VORONklipper` comes with its own `homing_override`. This changes the behaviour 
+of the Z homing. This is a convenience to allow you to configure the X/Y 
+coordinates of your Z-endstop pin in an easy to read place instead of modifying 
+or writing your own override.
+
+Besides that the included override also only homes X/Y again, if it has not 
+been homed already and does not contain any unnecessary move commands (like 
+centering the toolhead). This is done to save time when retrieving a new 
+Z-offset during `print_start`. You can still force homing X/Y with a 
+`G28 X0 Y0` if you feel the need to.
+
+> To make it work you have to remove your own `homing_override` from 
+`printer.cfg`.
+
+## __print end__
+```
+PRINT_END
+```
+Just retracts the filament, clears bed mesh and parks the toolhead at the back 
+of the printer. 
+
+> To make it work you have to remove your own gcode macro 
+`print_end` from `printer.cfg`.
+
+## __print start__
+```
+PRINT_START EXTRUDER=<extruder temperature> [BED=<bed temperature>] [PROFILE=<profile name>] [CLEAN=true]
+```
+Macro to automate print starts for different profiles. You can call this from 
+your slicer as start gcode. 
+
+It will 
+1. heat up the bed/extruder to the desired temperatures
+2. perform QGL 
+3. perform nozzle cleaning if `CLEAN=true` is specified
+4. load the bed mesh for the given profile name if `PROFILE` parameter is 
+   specified
+
+This macro has an optimized order of actions. That means heating will start 
+emmideately while the printer does its initial homing. It will then center over 
+the print bed and wait for the target temperature. 
+
+QGL and nozzle cleaning can throw off the Z-offset, so this macro ensures that 
+after every relevant step Z is homed again to have a correct Z-offset for the 
+next step. It is highly recommended, that you use the built in 
+`homing_override` instead of your own if possible, because it skips rehoming 
+X/Y after every step. Especially after cleaning the nozzle this is important, 
+because new plastic could ooze out of the nozzle and throw off the offset.
+
+> _Please note:_ If you do not provide a profile, no bed mesh will be used.
+
+> To make it work you have to remove your own gcode macro `print_start` from `printer.cfg`.

--- a/essentials.cfg
+++ b/essentials.cfg
@@ -7,6 +7,14 @@
 # Provides essential macros for use in other parts of the VORON CONFIG MOD
 ################################################################################
 
+[gcode_macro CHECK_VORON_CONFIG]
+gcode:
+    {% if printer["gcode_macro VORON_CONFIG"] is not defined %}
+        { action_raise_error(
+            "VORON_CONFIG: Error\n"
+            "Your VORONklipper config is missing.\n"
+            "Visit https://github.com/rampage128/voron-klipper for more info.") }
+    {% endif %}
 
 ################################################################################
 # CLEAR DISPLAY

--- a/essentials.cfg
+++ b/essentials.cfg
@@ -7,10 +7,20 @@
 # Provides essential macros for use in other parts of the VORON CONFIG MOD
 ################################################################################
 
+################################################################################
+# CONFIG CHECK
+# Helper macro to raise an error if the VORON CONFIG gcode macro is missing. 
+
+# This macro is called by various other macros that require configuration.
+# It will raise an error to prevent printer malfunction due to missing 
+# parameters. 
+# FIXME: Currently the output of action_raise_error will be printed twice. 
+# This happens when CHECK_VORON_CONFIG is called from another macro.
+################################################################################
 [gcode_macro CHECK_VORON_CONFIG]
 gcode:
     {% if printer["gcode_macro VORON_CONFIG"] is not defined %}
-        { action_raise_error(
+        { action_respond_info(
             "VORON_CONFIG: Error\n"
             "Your VORONklipper config is missing.\n"
             "Visit https://github.com/rampage128/voron-klipper for more info.") }

--- a/essentials.cfg
+++ b/essentials.cfg
@@ -1,7 +1,7 @@
 ################################################################################
 # VORON CONFIG MOD
 # Copyright 2020 Frederik Wolter
-# https://github.com/rampage128/voron-mods
+# https://github.com/rampage128/voron-klipper
 
 # ESSENTIALS COMPONENT
 # Provides essential macros for use in other parts of the VORON CONFIG MOD

--- a/main.cfg
+++ b/main.cfg
@@ -1,7 +1,7 @@
 ################################################################################
 # VORON CONFIG MOD
 # Copyright 2020 Frederik Wolter
-# https://github.com/rampage128/voron-mods
+# https://github.com/rampage128/voron-klipper
 
 # MAIN CONFIG
 # Loads all other components of VORON CONFIG MOD

--- a/main.cfg
+++ b/main.cfg
@@ -17,3 +17,6 @@
 
 # Printing component for some print related convenience
 [include print.cfg]
+
+# Configurable printer overrides
+[include overrides.cfg]

--- a/motion.cfg
+++ b/motion.cfg
@@ -143,6 +143,7 @@ gcode:
 
         RESTORE_GCODE_STATE NAME=NOZZLE_CLEAN
     {% endif %}
+    
 
 ################################################################################
 # SERVICE MODE

--- a/motion.cfg
+++ b/motion.cfg
@@ -98,55 +98,51 @@ gcode:
 [gcode_macro CLEAN_NOZZLE]
 default_parameter_STROKES: 5
 gcode:
-    {% if "X" not in params or "Y" not in params or "Z" not in params or "O" not in params or "L" not in params %}
-        { action_raise_error(
-            "NOZZLE_CLEAN: Error\n"
-            "Illegal options\n"
-            "Please specify X, Y, Z, O and L.") }
+    CHECK_VORON_CONFIG
+    {% if printer["gcode_macro VORON_CONFIG"] is defined and printer["gcode_macro VORON_CONFIG"].brush_active == "true" %}
+        {% set posX = printer["gcode_macro VORON_CONFIG"].brush_x|float %}
+        {% set posY = printer["gcode_macro VORON_CONFIG"].brush_y|float %}
+        {% set posZ = printer["gcode_macro VORON_CONFIG"].brush_z|float %}
+        {% set posZClear = posZ + 5 %}
+        {% set length = printer["gcode_macro VORON_CONFIG"].brush_width|float %}
+        {% set numStrokes = printer["gcode_macro VORON_CONFIG"].brush_strokes|int %}
+        {% set feedRate = length * 60 %}
+
+        {% set startX = posX %}
+        {% set startY = posY %}
+        {% set endX = posX %}
+        {% set endY = posY %}
+
+        {% if printer["gcode_macro VORON_CONFIG"].brush_orientation == "y" %}
+            {% set startY = posY - length / 2 %}
+            {% set endY = posY + length / 2 %}
+        {% else %}
+            {% set startX = posX - length / 2 %}
+            {% set endX = posX + length / 2 %}
+        {% endif %}
+
+        FEEDBACK MSG="Clean: Homing"
+        HOME OPTIONAL=true
+
+        SAVE_GCODE_STATE NAME=NOZZLE_CLEAN
+
+        FEEDBACK MSG="Clean: Moving"
+        G90
+        G0 Z{posZClear}
+        G0 X{startX} Y{startY} F3600
+        G0 Z{posZ}
+        FEEDBACK MSG="Clean: Cleaning"
+        {% for stroke in range(0, numStrokes) %}
+            G0 X{endX} Y{endY} F{feedRate}
+            G0 X{startX} Y{startY} F{feedRate}
+        {% endfor %}
+        G0 Z{posZClear}
+
+        FEEDBACK MSG="Clean: Done"
+        UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
+
+        RESTORE_GCODE_STATE NAME=NOZZLE_CLEAN
     {% endif %}
-
-    {% set posX = params.X|float %}
-    {% set posY = params.Y|float %}
-    {% set posZ = params.Z|float %}
-    {% set posZClear = params.Z|float + 5 %}
-    {% set length = params.L|float %}
-    {% set numStrokes = params.STROKES|int %}
-    {% set feedRate = length * 60 %}
-
-    {% set startX = posX %}
-    {% set startY = posY %}
-    {% set endX = posX %}
-    {% set endY = posY %}
-
-    {% if params.O == "y" %}
-        {% set startY = posY - length / 2 %}
-        {% set endY = posY + length / 2 %}
-    {% else %}
-        {% set startX = posX - length / 2 %}
-        {% set endX = posX + length / 2 %}
-    {% endif %}
-
-    FEEDBACK MSG="Clean: Homing"
-    HOME OPTIONAL=true
-
-    SAVE_GCODE_STATE NAME=NOZZLE_CLEAN
-
-    FEEDBACK MSG="Clean: Moving"
-    G90
-    G0 Z{posZClear}
-    G0 X{startX} Y{startY} F3600
-    G0 Z{posZ}
-    FEEDBACK MSG="Clean: Cleaning"
-    {% for stroke in range(0, numStrokes) %}
-        G0 X{endX} Y{endY} F{feedRate}
-        G0 X{startX} Y{startY} F{feedRate}
-    {% endfor %}
-    G0 Z{posZClear}
-
-    FEEDBACK MSG="Clean: Done"
-    UPDATE_DELAYED_GCODE ID=clear_display DURATION=10
-
-    RESTORE_GCODE_STATE NAME=NOZZLE_CLEAN
 
 ################################################################################
 # SERVICE MODE

--- a/motion.cfg
+++ b/motion.cfg
@@ -1,7 +1,7 @@
 ################################################################################
 # VORON CONFIG MOD
 # Copyright 2020 Frederik Wolter
-# https://github.com/rampage128/voron-mods
+# https://github.com/rampage128/voron-klipper
 
 # MOTION COMPONENT
 # Provides macros for gantry motion to specific places

--- a/overrides.cfg
+++ b/overrides.cfg
@@ -1,0 +1,40 @@
+################################################################################
+# VORON CONFIG MOD
+# Copyright 2020 Frederik Wolter
+# https://github.com/rampage128/voron-mods
+
+# OVERRIDES COMPONENT
+# Provides overrides for common gcodes or macros
+################################################################################
+
+
+################################################################################
+# HOMING OVERRIDE
+# A configurable override for the z-homing routine
+
+# This override will do two things for convenience:
+# 1. It allows configuring the X and Y positions of the Z-endstop in the 
+#    config without having to edit the override gcode directly.
+# 2. It only performs homing of X and Y if they are not in a good homed state 
+#    already.
+################################################################################
+[homing_override]
+axes: z
+set_position_z: 0
+gcode:
+    CHECK_VORON_CONFIG
+    {% if printer["gcode_macro VORON_CONFIG"] is defined and printer["gcode_macro VORON_CONFIG"].z_endstop_x is defined and printer["gcode_macro VORON_CONFIG"].z_endstop_y is defined %}
+        G90
+        G0 Z5 F600
+        {% if "xy" not in printer.toolhead.homed_axes %}
+            G28 X Y
+        {% endif %}
+
+        G0 X{ printer["gcode_macro VORON_CONFIG"].z_endstop_x } Y{ printer["gcode_macro VORON_CONFIG"].z_endstop_y } F3600 
+    
+        G28 Z
+        G0 Z10 F1800
+    {% else %}
+        { action_raise_error("Can not home your printer.\n"
+                              "Please make sure you have defined variable_z_endstop_x and variable_z_endstop_y in your VORON_CONFIG!") }
+    {% endif %}

--- a/overrides.cfg
+++ b/overrides.cfg
@@ -1,7 +1,7 @@
 ################################################################################
 # VORON CONFIG MOD
 # Copyright 2020 Frederik Wolter
-# https://github.com/rampage128/voron-mods
+# https://github.com/rampage128/voron-klipper
 
 # OVERRIDES COMPONENT
 # Provides overrides for common gcodes or macros

--- a/print.cfg
+++ b/print.cfg
@@ -68,10 +68,28 @@ gcode:
 
 
 ################################################################################
-# PRINT START
-# A macro to end your print
+# PRINT END
+# A macro to execute when your print is done
 ################################################################################
 [gcode_macro PRINT_END]
+gcode:
+    M400                           ; wait for buffer to clear
+    BED_MESH_CLEAR
+    G92 E0                         ; zero the extruder
+    G1 E-10.0 F3600                ; retract filament
+    G91                            ; relative positioning
+    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    TURN_OFF_HEATERS
+    M107                           ; turn off fan
+    G1 Z2 F3000                    ; move nozzle up 2mm
+    G90                            ; absolute positioning
+    PARK HOP=5
+
+################################################################################
+# PRINT CANCEL
+# A macro to execute when your print is canceled
+################################################################################
+[gcode_macro PRINT_CANCEL]
 gcode:
     M400                           ; wait for buffer to clear
     BED_MESH_CLEAR

--- a/print.cfg
+++ b/print.cfg
@@ -1,7 +1,7 @@
 ################################################################################
 # VORON CONFIG MOD
 # Copyright 2020 Frederik Wolter
-# https://github.com/rampage128/voron-mods
+# https://github.com/rampage128/voron-klipper
 
 # PRINTING COMPONENT
 # Provides common macros for print preparation and finalizing

--- a/print.cfg
+++ b/print.cfg
@@ -93,14 +93,9 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     BED_MESH_CLEAR
-    G92 E0                         ; zero the extruder
-    G1 E-10.0 F3600                ; retract filament
-    G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
-    G90                            ; absolute positioning
+    G1 Z5 F3000                    ; move nozzle up 5mm
     PARK HOP=5
 
 

--- a/print.cfg
+++ b/print.cfg
@@ -28,18 +28,8 @@
 ################################################################################
 [gcode_macro PRINT_START]
 default_parameter_BED: 0
+default_parameter_CLEAN: false
 gcode:
-    # Validate cleaning parameter syntax
-    {% if "CLEAN" in params %}
-        {% set cp = params.CLEAN.split(",") %}
-        {% if cp|count != 6 %}
-            { action_raise_error(
-            "PRINT_START: Error\n"
-            "Illegal CLEAN option\n"
-            "Please specify X,Y,Z,O,L,STROKES.\n"
-            "See documentation for more info.") }
-        {% endif %}
-    {% endif %}
     # Start bed heating
     HEAT BED={ params.BED } EXTRUDER={ params.EXTRUDER } BLOCK=false
     # Clear any applied bed mesh
@@ -55,11 +45,11 @@ gcode:
     FEEDBACK MSG="Print: Leveling"
     QUAD_GANTRY_LEVEL
     # Clean Nozzle if specified (we also need to home again after QGL)
-    {% if "CLEAN" in params %}
+    {% if params.CLEAN == "true" %}
         {% set cp = params.CLEAN.split(",") %}
         FEEDBACK MSG="Print: Cleaning"
         HOME
-        CLEAN_NOZZLE X={cp[0]} Y={cp[1]} Z={cp[2]} O={cp[3]} L={cp[4]} STROKES={cp[5]}
+        CLEAN_NOZZLE
     {% endif %}
     # Retrieve final Z with cleaned nozzle
     FEEDBACK MSG="Print: Z-offset"


### PR DESCRIPTION
This PR introduces the macro configuration for the provided features.

Until now macros that required coordinates or other static information used parameters.
This leads to the need to repeat the same parameters if you want to call the same macros from different locations.

Now these static items can be added to a `gcode_macro` that serves as configuration layer inside the `printer.cfg` file.

The new configuration layer also allows to add overrides (like the `homing_override`) to the collection, since they can also read variables from the configuration macro. 😎 

Since this complicates usage a bit I have also split up the documentation, moved it into it's own folder and made it a bit more 
comprehensive.